### PR TITLE
chore: clean up error message when copying fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,8 +22,12 @@ export function mihoy() {
     const output = lines.join('\n');
 
     // Copy the output to the clipboard
-    clipboardy.writeSync(output);
-    console.log(`Copied to clipboard!`);
+    try {
+      clipboardy.writeSync(output);
+      console.log(`Copied to clipboard!`);
+    } catch (err) {
+      console.error(`\nError copying to clipboard: ${"message" in err ? err.message : err}`);
+    }
   } else {
     console.error('Please provide exactly one command line argument.');
   }


### PR DESCRIPTION
Before:

<img width="1795" alt="Screenshot 2023-12-07 at 3 33 19 PM" src="https://github.com/maxdemaio/mihoy-npm/assets/2035492/64afb804-ba7b-43af-a436-e56e33b7d9cb">

After:

<img width="1795" alt="Screenshot 2023-12-07 at 3 33 47 PM" src="https://github.com/maxdemaio/mihoy-npm/assets/2035492/2e8ac1b2-9f6f-4fd2-8fd8-e513819dc586">
